### PR TITLE
Fix XTTS initialization to match BaseTTS signature

### DIFF
--- a/xtts.py
+++ b/xtts.py
@@ -199,7 +199,7 @@ class Xtts(BaseTTS):
     """
 
     def __init__(self, config: Coqpit):
-        super().__init__(config, ap=None, tokenizer=None)
+        super().__init__(config)
         self.mel_stats_path = None
         self.config = config
         self.gpt_checkpoint = self.args.gpt_checkpoint


### PR DESCRIPTION
## Summary
- remove outdated arguments from the XTTS base class initialization so it matches the BaseTTS constructor

## Testing
- not run (not run)

------
https://chatgpt.com/codex/tasks/task_e_68e4333ab81c832fbb53180a690152fe