### PR TITLE
Update streaming latency metric to average chunk time

### DIFF
--- a/infer_xtts.py
+++ b/infer_xtts.py
@@ -175,7 +175,7 @@ def main() -> None:
                 print(f"  Time to first audio: {metrics.time_to_first_audio:.3f}s")
             if metrics.real_time_factor is not None:
                 print(f"  Real-time factor: {metrics.real_time_factor:.3f}")
-            print(f"  Latency: {metrics.latency:.3f}s")
+            print(f"  Latency (avg chunk): {metrics.latency:.3f}s")
     else:
         result = model.synthesize(
             text=args.text,


### PR DESCRIPTION
## Summary
- compute streaming latency as the average time between emitted audio chunks
- expose the updated meaning in the CLI streaming metrics output

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e591f5b9b0832f988767679b835656